### PR TITLE
New version that works with QuickCheck >= 2.7

### DIFF
--- a/QuickCheck-GenT.cabal
+++ b/QuickCheck-GenT.cabal
@@ -1,7 +1,7 @@
 name:
   QuickCheck-GenT
 version:
-  0.1.4
+  0.2.0
 synopsis:
   A GenT monad transformer for QuickCheck library.
 description:
@@ -42,7 +42,7 @@ library
   other-modules:
     QuickCheck.GenT.Prelude
   build-depends:
-    QuickCheck < 2.7,
+    QuickCheck >= 2.7,
     random,
     mtl,
     base >= 4.5 && < 5

--- a/src/QuickCheck/GenT.hs
+++ b/src/QuickCheck/GenT.hs
@@ -6,10 +6,11 @@ module QuickCheck.GenT where
 
 import QuickCheck.GenT.Prelude
 import qualified Test.QuickCheck.Gen as QC
+import qualified Test.QuickCheck.Random as QC
 import qualified System.Random as Random
 
 
-newtype GenT m a = GenT { unGenT :: Random.StdGen -> Int -> m a }
+newtype GenT m a = GenT { unGenT :: QC.QCGen -> Int -> m a }
 
 instance (Functor m) => Functor (GenT m) where
   fmap f m = GenT $ \r n -> fmap f $ unGenT m r n
@@ -61,7 +62,7 @@ instance MonadGen QC.Gen where
 -- of (fst . split) and (snd . split) applications.  Every integer (including 
 -- negative ones) will give rise to a different random number generator in 
 -- log2 n steps. 
-var :: Integral n => n -> Random.StdGen -> Random.StdGen 
+var :: Integral n => n -> QC.QCGen -> QC.QCGen
 var k = 
   (if k == k' then id else var k') . (if even k then fst else snd) . Random.split 
   where k' = k `div` 2 


### PR DESCRIPTION
In v2.7 `QuickCheck.Gen` started using `QCGen`instead of `StdGen`. To support newer versions of QuickCheck we can just replace StdGen with QCGen and it should just work.

I tested it with QuickCheck 2.7 and QuickCheck 2.8.2 on GHC 7.10.2.
